### PR TITLE
Replace MooseX::MarkAsMethods with namespace::autoclean (RT#100003)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Catalyst::Model::DBIC::Schema
 
+0.67
+        - replace MooseX::MarkAsMethods with namespace::autoclean (RT#100003)
+
 0.66  2023-07-30 07:45:00
         - fix Makefile.PL to work properly in newer perls without . in @INC
         - update repository link in metadata

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,12 +9,11 @@ requires 'DBIx::Class'           => '0.08114';
 requires 'Catalyst::Runtime'     => '5.80005';
 requires 'CatalystX::Component::Traits' => '0.14';
 
-requires 'Moose' => '1.12';
-requires 'MooseX::MarkAsMethods' => '0.13';
+requires 'Moose' => '2.14';
 requires 'MooseX::Types';
 requires 'MooseX::Types::LoadableClass' => 0.009;
 requires 'Module::Runtime' => '0.012';
-requires 'namespace::autoclean' => 0.09;
+requires 'namespace::autoclean' => 0.16;
 requires 'Carp::Clan';
 requires 'List::MoreUtils';
 requires 'Tie::IxHash';

--- a/lib/Catalyst/TraitFor/Model/DBIC/Schema/PerRequestSchema.pm
+++ b/lib/Catalyst/TraitFor/Model/DBIC/Schema/PerRequestSchema.pm
@@ -1,7 +1,7 @@
 package Catalyst::TraitFor::Model::DBIC::Schema::PerRequestSchema;
 
 use Moose::Role;
-use MooseX::MarkAsMethods autoclean => 1;
+use namespace::autoclean;
 
 with 'Catalyst::Component::InstancePerContext';
 


### PR DESCRIPTION
This solves https://rt.cpan.org/Public/Bug/Display.html?id=100003.

All other modules already use `namespace::autoclean`. Only `Catalyst::TraitFor::Model::DBIC::Schema::PerRequestSchema` used `MooseX::MarkAsMethods` since 566a0bcace1f933a42a84e4b92782d78911acbba.